### PR TITLE
Wrong ID in Query Vector

### DIFF
--- a/apps/sample_queries.cpp
+++ b/apps/sample_queries.cpp
@@ -44,7 +44,7 @@ int main(int argc, char ** argv) {
             indexFout << queryIdx << " -> " << i << endl;
             queryIdx++;
 
-            fout.write((char*)&dimension, sizeof(int));
+            fout.write((char*)&i, sizeof(int));
             fout.write((char*)data[i], dimension * sizeof(float));
         }
     }


### PR DESCRIPTION
In the previous version, the IDs of query vector are wrong.

Now fixed it~